### PR TITLE
Add button class prop.

### DIFF
--- a/src/AccordionItem.svelte
+++ b/src/AccordionItem.svelte
@@ -3,6 +3,7 @@
   export let title = "Title";
   export let expanded = false;
   export let disabled = false;
+  export let buttonClass = "";
 
   import { getContext, onDestroy } from "svelte";
 
@@ -50,6 +51,7 @@
 
 <li {...$$restProps}>
   <button
+    class={buttonClass}
     bind:this={ref}
     aria-expanded={expanded}
     aria-controls={id}


### PR DESCRIPTION
Simple PR to add a property for setting classes on the button. My use case was to add a 'group' class so that Tailwind utility classes could be used to style elements within the title when expanded.